### PR TITLE
Add endpoint to retrieve my profile information

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,26 @@
+name: Kotlin CI with Gradle
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Run Tests
+        run: ./gradlew test

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ out/
 .kotlin
 
 ### Properties ###
-application-env.properties
+*.properties

--- a/src/main/kotlin/com/likelionhgu/stepper/exception/MemberNotFoundException.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/exception/MemberNotFoundException.kt
@@ -1,4 +1,4 @@
 package com.likelionhgu.stepper.exception
 
-class MemberNotFoundException(message: String) : RuntimeException(message) {
+class MemberNotFoundException(message: String = "The member does not exist") : RuntimeException(message) {
 }

--- a/src/main/kotlin/com/likelionhgu/stepper/member/Member.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/member/Member.kt
@@ -1,5 +1,6 @@
 package com.likelionhgu.stepper.member
 
+import com.likelionhgu.stepper.common.BaseTime
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -19,7 +20,7 @@ class Member(
 
     @Column
     val picture: String? = null
-) {
+) : BaseTime() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val memberId = 0L

--- a/src/main/kotlin/com/likelionhgu/stepper/member/MemberController.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/member/MemberController.kt
@@ -1,0 +1,24 @@
+package com.likelionhgu.stepper.member
+
+import com.likelionhgu.stepper.member.response.MemberResponse
+import com.likelionhgu.stepper.security.oauth2.CommonOAuth2Attribute
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MemberController(
+    private val memberService: MemberService
+) {
+
+    @GetMapping("/v1/members/my")
+    fun getMyInfo(
+        @AuthenticationPrincipal user: CommonOAuth2Attribute
+    ): ResponseEntity<MemberResponse> {
+        val member = memberService.memberInfo(user.oauth2UserId)
+        val responseBody = MemberResponse.of(member)
+
+        return ResponseEntity.ok(responseBody)
+    }
+}

--- a/src/main/kotlin/com/likelionhgu/stepper/member/MemberService.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/member/MemberService.kt
@@ -1,0 +1,24 @@
+package com.likelionhgu.stepper.member
+
+import com.likelionhgu.stepper.exception.MemberNotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class MemberService(
+    private val memberRepository: MemberRepository
+) {
+    /**
+     * Retrieves the basic information of a member based on their OAuth2 ID.
+     *
+     * @param oauth2Id The OAuth2 ID of the member. This ID is used to uniquely identify and retrieve the member
+     *                 from the repository.
+     * @return Member The `Member` entity corresponding to the provided OAuth2 ID. This object contains the
+     *                 basic information of the member.
+     * @throws MemberNotFoundException if no member is found with the provided OAuth2 ID. This exception signals
+     *                                  that the requested member could not be found in the repository.
+     */
+    fun memberInfo(oauth2Id: String): Member {
+        return memberRepository.findByOauth2Id(oauth2Id)
+            ?: throw MemberNotFoundException()
+    }
+}

--- a/src/main/kotlin/com/likelionhgu/stepper/member/response/MemberResponse.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/member/response/MemberResponse.kt
@@ -1,0 +1,18 @@
+package com.likelionhgu.stepper.member.response
+
+import com.likelionhgu.stepper.member.Member
+
+class MemberResponse(
+    val name: String?,
+    val thumbnail: String?
+) {
+
+    companion object {
+        fun of(member: Member): MemberResponse {
+            return MemberResponse(
+                name = member.name,
+                thumbnail = member.picture
+            )
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,26 +1,26 @@
 spring:
   profiles:
-    include: env
+    include: local
   security:
     oauth2:
       client:
         registration:
           google:
-            client-id: ${GOOGLE_CLIENT_ID}
-            client-secret: ${GOOGLE_CLIENT_SECRET}
+            client-id: # Required
+            client-secret: # Required
             scope: email, profile
   data:
     redis:
-      host: ${REDIS_HOST:localhost}
-      password: ${REDIS_PASSWORD}
+      host: localhost
+      password:
   datasource:
-    driver-class-name: ${DB_DRIVER:org.h2.Driver}
-    url: ${DB_URL:jdbc:h2:mem:testdb}
-    username: ${DB_USER:sa}
-    password: ${DB_PASSWORD:}
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
   h2:
     console:
-      enabled: ${H2_CONSOLE:true} # Set to false in production
+      enabled: true
 server:
   servlet:
     session:
@@ -28,8 +28,8 @@ server:
         name: JSESSIONID
         http-only: true
         same-site: none
-        secure: ${COOKIE_SECURE:false} # Set to true in production
+        secure: true
         max-age: 3600
 custom:
   host:
-    client: ${HOST_CLIENT:http://localhost:3000}
+    client: http://localhost:3000

--- a/src/test/kotlin/com/likelionhgu/stepper/goal/GoalServiceTest.kt
+++ b/src/test/kotlin/com/likelionhgu/stepper/goal/GoalServiceTest.kt
@@ -5,6 +5,7 @@ import com.likelionhgu.stepper.goal.request.GoalRequest
 import com.likelionhgu.stepper.member.Member
 import com.likelionhgu.stepper.member.MemberRepository
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
@@ -30,9 +31,8 @@ class GoalServiceTest(
         val request = GoalRequest(title = goalTitle)
 
         `when`("the goal is created") {
-            val goalId = goalService.createGoal(oauth2UserId, request)
-
             then("the goal should be in the database") {
+                val goalId = goalService.createGoal(oauth2UserId, request)
                 val goal = goalRepository.findById(goalId).getOrNull()
 
                 goal shouldNotBe null
@@ -49,30 +49,33 @@ class GoalServiceTest(
         val goalId2 = goalService.createGoal(oauth2UserId, request2)
 
         `when`("the goals are retrieved with an order of recent") {
-            val goals = goalService.memberGoals(oauth2UserId, GoalSortType.NEWEST)
-
             then("the goals should be sorted by recent") {
+                val goals = goalService.memberGoals(oauth2UserId, GoalSortType.NEWEST)
+
                 goals[0].goalId shouldBe goalId2
                 goals[1].goalId shouldBe goalId1
             }
         }
 
         `when`("the goals are retrieved with an order of ascending") {
-            val goals = goalService.memberGoals(oauth2UserId, GoalSortType.ASC)
-
             then("the goals should be sorted by ascending") {
+                val goals = goalService.memberGoals(oauth2UserId, GoalSortType.ASC)
+
                 goals[0].goalId shouldBe goalId1
                 goals[1].goalId shouldBe goalId2
             }
         }
 
         `when`("the goals are retrieved with an order of descending") {
-            val goals = goalService.memberGoals(oauth2UserId, GoalSortType.DESC)
 
             then("the goals should be sorted by ascending") {
+                val goals = goalService.memberGoals(oauth2UserId, GoalSortType.DESC)
+
                 goals[0].goalId shouldBe goalId2
                 goals[1].goalId shouldBe goalId1
             }
         }
     }
-})
+}) {
+    override fun extensions() = listOf(SpringExtension)
+}

--- a/src/test/kotlin/com/likelionhgu/stepper/member/MemberServiceTest.kt
+++ b/src/test/kotlin/com/likelionhgu/stepper/member/MemberServiceTest.kt
@@ -20,9 +20,9 @@ class MemberServiceTest : BehaviorSpec({
             picture = "https://example.com/johndoe.jpg"
         )
         `when`("try to get the member profile by oauth2Id") {
-            val member = memberService.memberInfo(oauth2Id)
-
             then("the member should have the correct information") {
+                val member = memberService.memberInfo(oauth2Id)
+
                 member.oauth2Id shouldBe oauth2Id
                 member.email shouldBe email
             }

--- a/src/test/kotlin/com/likelionhgu/stepper/member/MemberServiceTest.kt
+++ b/src/test/kotlin/com/likelionhgu/stepper/member/MemberServiceTest.kt
@@ -1,0 +1,31 @@
+package com.likelionhgu.stepper.member
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class MemberServiceTest : BehaviorSpec({
+    val memberRepository = mockk<MemberRepository>()
+    val memberService = MemberService(memberRepository)
+
+    given("A member is created") {
+        val oauth2Id = "123"
+        val email = "johndoe@example.com"
+
+        every { memberRepository.findByOauth2Id(oauth2Id) } returns Member(
+            oauth2Id = oauth2Id,
+            email = email,
+            name = "John Doe",
+            picture = "https://example.com/johndoe.jpg"
+        )
+        `when`("try to get the member profile by oauth2Id") {
+            val member = memberService.memberInfo(oauth2Id)
+
+            then("the member should have the correct information") {
+                member.oauth2Id shouldBe oauth2Id
+                member.email shouldBe email
+            }
+        }
+    }
+})


### PR DESCRIPTION
- The endpoint returns the username and profile image given by the OAuth 2 provider.
- Authentication required
- Add yml file for CI* (See `.github/workflows/testing.yml`)