### PR TITLE
Implement searching journal entries

### DIFF
--- a/src/main/kotlin/com/likelionhgu/stepper/journal/JournalController.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/journal/JournalController.kt
@@ -40,10 +40,14 @@ class JournalController(
     @GetMapping("/v1/goals/{goalId}/journals")
     fun displayJournals(
         @PathVariable goalId: String,
-        @RequestParam(required = false) sort: JournalSortType = JournalSortType.NEWEST
+        @RequestParam(required = false) sort: JournalSortType = JournalSortType.NEWEST,
+        @RequestParam(required = false) q: String?
     ): ResponseEntity<JournalResponseWrapper> {
+        // Handle query as null if it is an empty string
+        val searchKeyword = q?.takeIf(String::isNotBlank)
+
         val goal = goalService.goalInfo(goalId)
-        val journals = journalService.journalsOf(goal, sort)
+        val journals = journalService.journalsOf(goal, sort, searchKeyword)
 
         val responseBody = JournalResponseWrapper.of(goal, journals)
         return ResponseEntity.ok(responseBody)

--- a/src/main/kotlin/com/likelionhgu/stepper/journal/JournalRepository.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/journal/JournalRepository.kt
@@ -3,7 +3,14 @@ package com.likelionhgu.stepper.journal;
 import com.likelionhgu.stepper.goal.Goal
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface JournalRepository : JpaRepository<Journal, Long> {
-    fun findAllByGoal(goal: Goal, sort: Sort): List<Journal>
+
+    @Query(
+        "select j from Journal j where j.goal = :goal " +
+                "and ((:searchKeyword is null or j.title like %:searchKeyword%) " +
+                "or (:searchKeyword is null or j.content like %:searchKeyword%))"
+    )
+    fun findAllByGoalWithQuery(goal: Goal, sort: Sort, searchKeyword: String?): List<Journal>
 }

--- a/src/main/kotlin/com/likelionhgu/stepper/journal/JournalService.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/journal/JournalService.kt
@@ -35,7 +35,7 @@ class JournalService(
      * @param sortType The sorting type of the journals.
      * @return A list of journals for the goal ordered by the sorting type.
      */
-    fun journalsOf(goal: Goal, sortType: JournalSortType): List<Journal> {
-        return journalRepository.findAllByGoal(goal, sortType.toSort())
+    fun journalsOf(goal: Goal, sortType: JournalSortType, searchKeyword: String?): List<Journal> {
+        return journalRepository.findAllByGoalWithQuery(goal, sortType.toSort(), searchKeyword)
     }
 }

--- a/src/test/kotlin/com/likelionhgu/stepper/journal/JournalControllerTest.kt
+++ b/src/test/kotlin/com/likelionhgu/stepper/journal/JournalControllerTest.kt
@@ -63,7 +63,7 @@ class JournalControllerTest(
 
     given("a member who has created a goal and written some journal entries") {
         every { goalService.goalInfo(any()) } returns Goal(title = "title", member = mockk())
-        every { journalService.journalsOf(any(), any()) } returns listOf(
+        every { journalService.journalsOf(any(), any(), any()) } returns listOf(
             Journal(
                 "title1",
                 "content",

--- a/src/test/kotlin/com/likelionhgu/stepper/journal/JournalRepositoryTest.kt
+++ b/src/test/kotlin/com/likelionhgu/stepper/journal/JournalRepositoryTest.kt
@@ -7,7 +7,6 @@ import com.likelionhgu.stepper.member.Member
 import com.likelionhgu.stepper.member.MemberRepository
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.spring.SpringExtension
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 
@@ -26,7 +25,7 @@ class JournalRepositoryTest(
 
         `when`("the member requests to see the journal entries with default order") {
             then("the journal entries should be returned ordered by created date in descending order") {
-                val actual = journalRepository.findAllByGoal(goal, JournalSortType.NEWEST.toSort())
+                val actual = journalRepository.findAllByGoalWithQuery(goal, JournalSortType.NEWEST.toSort(), null)
 
                 actual[0].journalId shouldBe j2.journalId
                 actual[1].journalId shouldBe j1.journalId
@@ -35,10 +34,35 @@ class JournalRepositoryTest(
 
         `when`("the member requests to see the journal entries with oldest order") {
             then("the journal entries should be returned ordered by created date in ascending order") {
-                val actual = journalRepository.findAllByGoal(goal, JournalSortType.OLDEST.toSort())
+                val actual = journalRepository.findAllByGoalWithQuery(goal, JournalSortType.OLDEST.toSort(), null)
 
                 actual[0].journalId shouldBe j1.journalId
                 actual[1].journalId shouldBe j2.journalId
+            }
+        }
+
+        `when`("the member searches for a journal entry with a keyword 'title1'") {
+            then("the journal entries should be returned that contain the keyword") {
+                val actual = journalRepository.findAllByGoalWithQuery(goal, JournalSortType.NEWEST.toSort(), "title1")
+
+                actual.size shouldBe 1
+                actual[0].journalId shouldBe j1.journalId
+            }
+        }
+
+        `when`("the member searches for a journal entry with a keyword 'content'") {
+            then("the journal entries should be returned that contain the keyword") {
+                val actual = journalRepository.findAllByGoalWithQuery(goal, JournalSortType.NEWEST.toSort(), "content")
+
+                actual.size shouldBe 2
+            }
+        }
+
+        `when`("the member searches for a journal entry with a keyword that does not exist") {
+            then("no journal entries should be returned") {
+                val actual = journalRepository.findAllByGoalWithQuery(goal, JournalSortType.NEWEST.toSort(), "keyword")
+
+                actual.size shouldBe 0
             }
         }
     }

--- a/src/test/kotlin/com/likelionhgu/stepper/journal/JournalServiceTest.kt
+++ b/src/test/kotlin/com/likelionhgu/stepper/journal/JournalServiceTest.kt
@@ -7,7 +7,6 @@ import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
-import org.springframework.data.domain.Sort
 
 class JournalServiceTest : BehaviorSpec({
     val journalRepository = mockk<JournalRepository>()
@@ -27,7 +26,7 @@ class JournalServiceTest : BehaviorSpec({
     }
 
     given("a member who has written some journal entries") {
-        every { journalRepository.findAllByGoal(any(), any()) } returns listOf(
+        every { journalRepository.findAllByGoalWithQuery(any(), any(), any()) } returns listOf(
             Journal(
                 "title1",
                 "content",
@@ -44,7 +43,7 @@ class JournalServiceTest : BehaviorSpec({
 
         `when`("the member requests to see the journal entries") {
             then("the journal entries should be returned") {
-                val journals = journalService.journalsOf(mockk(), JournalSortType.NEWEST)
+                val journals = journalService.journalsOf(mockk(), JournalSortType.NEWEST, null)
 
                 journals.size shouldNotBe 0
             }


### PR DESCRIPTION
- Query policy: search journals that contain the keyword in the title **OR** the content.
- If no keyword is specified, then retrieve all journals.