### PR TITLE
Change message order in reverse when fetching chat history

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -86,7 +86,7 @@ paths:
               examples:
                 S3ResponseExample:
                   value:
-                    url: https://3-namsong-st.s3.ap-northeast-2.amazonaws.com/goals/b46f73d9-fa83-4331-b37d-996897280aa6.jpeg...
+                    imageUrl: https://3-namsong-st.s3.ap-northeast-2.amazonaws.com/goals/b46f73d9-fa83-4331-b37d-996897280aa6.jpeg...
 
   # goals
   /v1/goals:

--- a/src/main/kotlin/com/likelionhgu/stepper/chat/ChatService.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/chat/ChatService.kt
@@ -58,6 +58,7 @@ class ChatService(
      */
     fun chatHistoryOf(chatId: String): MessageResponseWrapper {
         return assistantService.listMessagesOf(chatId).resolve()
+            ?.let(MessageResponseWrapper.Companion::reverseOf)
             ?: throw FailedThreadException("Failed to get chat history for thread $chatId")
     }
 

--- a/src/main/kotlin/com/likelionhgu/stepper/chat/response/ChatHistoryResponseWrapper.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/chat/response/ChatHistoryResponseWrapper.kt
@@ -14,7 +14,7 @@ data class ChatHistoryResponseWrapper(val messages: List<ChatHistoryResponse>) {
                     role = ChatRole.of(message.role),
                     content = message.content.first().text.value
                 )
-            }.reversed()
+            }
             return ChatHistoryResponseWrapper(messages)
         }
 

--- a/src/main/kotlin/com/likelionhgu/stepper/openai/assistant/message/MessageResponseWrapper.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/openai/assistant/message/MessageResponseWrapper.kt
@@ -17,4 +17,10 @@ data class MessageResponseWrapper(val data: List<MessageResponse>) {
             )
         }
     }
+
+    companion object {
+        fun reverseOf(response: MessageResponseWrapper): MessageResponseWrapper {
+            return MessageResponseWrapper(response.data.reversed())
+        }
+    }
 }


### PR DESCRIPTION
Since fetching messages API provides messages in newest order, change the order in reverse so that the history comes in oldeset order