### PR TITLE
Remove last message in chat history when sending a request to completion API

### DIFF
--- a/src/main/kotlin/com/likelionhgu/stepper/chat/ChatService.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/chat/ChatService.kt
@@ -124,7 +124,7 @@ class ChatService(
     }
 
     fun generateSummaryOf(chatId: String): ChatSummaryResponse {
-        val chatHistory = chatHistoryOf(chatId).toSimpleMessage()
+        val chatHistory = chatHistoryOf(chatId).removeLast().toSimpleMessage()
 
         with(openAiProperties.completion) {
             val requestBody = CompletionRequest.of(modelType.id, instructions, chatHistory)

--- a/src/main/kotlin/com/likelionhgu/stepper/openai/assistant/message/MessageResponseWrapper.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/openai/assistant/message/MessageResponseWrapper.kt
@@ -18,6 +18,10 @@ data class MessageResponseWrapper(val data: List<MessageResponse>) {
         }
     }
 
+    fun removeLast(): MessageResponseWrapper {
+        return MessageResponseWrapper(data.dropLast(1))
+    }
+
     companion object {
         fun reverseOf(response: MessageResponseWrapper): MessageResponseWrapper {
             return MessageResponseWrapper(response.data.reversed())


### PR DESCRIPTION
- Since the last message in chat history is always a question from the assistant, drop it when sending a request to completion API