### PR TITLE
Remove last message if role is assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 
 ### Properties ###
 *.properties
+application-*.yml

--- a/src/main/kotlin/com/likelionhgu/stepper/openai/assistant/message/MessageResponseWrapper.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/openai/assistant/message/MessageResponseWrapper.kt
@@ -1,5 +1,6 @@
 package com.likelionhgu.stepper.openai.assistant.message
 
+import com.likelionhgu.stepper.chat.ChatRole
 import com.likelionhgu.stepper.openai.SimpleMessage
 
 data class MessageResponseWrapper(val data: List<MessageResponse>) {
@@ -19,7 +20,10 @@ data class MessageResponseWrapper(val data: List<MessageResponse>) {
     }
 
     fun removeLast(): MessageResponseWrapper {
-        return MessageResponseWrapper(data.dropLast(1))
+        if (data.last().role == ChatRole.CHATBOT.alias) {
+            return MessageResponseWrapper(data.dropLast(1))
+        }
+        return this
     }
 
     companion object {


### PR DESCRIPTION
This patch addresses the issue where the OpenAI Completion API’s chat summary would return unexpected content.

Expected: A summary (or journal draft) of the chat.
Actual: The answer to the assistant’s last question.