### PR TITLE
Move instructions to the end of chat history

### DIFF
--- a/src/main/kotlin/com/likelionhgu/stepper/openai/completion/request/CompletionRequest.kt
+++ b/src/main/kotlin/com/likelionhgu/stepper/openai/completion/request/CompletionRequest.kt
@@ -8,14 +8,14 @@ data class CompletionRequest(
 ) {
     companion object {
         fun of(model: String, instructions: String, chatHistory: List<SimpleMessage>): CompletionRequest {
-            val systemMessage = SimpleMessage(
-                role = SYSTEM_ROLE,
+            val instructionMessage = SimpleMessage(
+                role = USER_ROLE,
                 content = instructions
             )
-            val messages = listOf(systemMessage).plus(chatHistory)
+            val messages = chatHistory.plus(instructionMessage)
             return CompletionRequest(model, messages)
         }
 
-        private const val SYSTEM_ROLE = "system"
+        private const val USER_ROLE = "user"
     }
 }


### PR DESCRIPTION
- AI를 활용한 일지 요약이 잘 되지 않는 것은 #39 에 처음 보고됨.
- 당시 이슈는 AI가 다음 질문을 생성하면서 요약 기능을 동시에 수행하도록 했을 때 요약이 제대로 되지 않는 것이었음.
- 이번 이슈는 이전 문제와 별개로 대화 내용에 대한 요약(expected) 대신 사용자의 마지막 응답에 대한 질문을 생성하는 것(actual)을 확인함.
- Open AI의 프롬프트 엔지니어링 가이드를 참고하여, 시스템 메시지에 배치한 지시사항을 기존 채팅 내역의 마지막에 추가하도록 수정.